### PR TITLE
Added PythonScript_OSXwallpapers.py

### DIFF
--- a/PythonScript_OSXwallpapers.py
+++ b/PythonScript_OSXwallpapers.py
@@ -1,0 +1,15 @@
+import sqlite3
+from os.path import expanduser
+
+# db_path found from: http://superuser.com/questions/664184
+db_path = expanduser("~/Library/Application Support/Dock/desktoppicture.db")
+wallpaper_dir = expanduser("~/Pictures/wallpaper/nature")
+
+conn = sqlite3.connect(db_path)
+c = conn.cursor()
+data_table = list(c.execute('SELECT * FROM data'))
+
+print(data_table)
+
+# The current wallpaper is the last element in the data table.
+print("{}/{}".format(wallpaper_dir, data_table[-1][0]))


### PR DESCRIPTION
A Python script that outputs the path of the current OSX wallpaper. This is helpful when the desktop wallpaper is randomized across a large collection of pictures and you want to delete the current wallpaper.